### PR TITLE
Fix for #9

### DIFF
--- a/lib/finance/rates.rb
+++ b/lib/finance/rates.rb
@@ -55,13 +55,13 @@ module Finance
     # @api private
     def compounds=(input)
       @periods = case input
-                 when :annually     then Flt::DecNum 1
+                 when :annually     then Flt::DecNum.new(1)
                  when :continuously then Flt::DecNum.infinity
-                 when :daily        then Flt::DecNum 365
-                 when :monthly      then Flt::DecNum 12
-                 when :quarterly    then Flt::DecNum 4
-                 when :semiannually then Flt::DecNum 2
-                 when Numeric       then Flt::DecNum input.to_s
+                 when :daily        then Flt::DecNum.new(365)
+                 when :monthly      then Flt::DecNum.new(12)
+                 when :quarterly    then Flt::DecNum.new(4)
+                 when :semiannually then Flt::DecNum.new(2)
+                 when Numeric       then Flt::DecNum.new(input.to_s)
                  else raise ArgumentError
                  end
     end
@@ -98,7 +98,7 @@ module Finance
 
       # Set the rate in the proper way, based on the value of type.
       begin
-        send("#{TYPES.fetch(type)}=", rate.to_d)
+        send("#{TYPES.fetch(type)}=", Flt::DecNum.new(rate.to_d))
       rescue KeyError
         raise ArgumentError, "type must be one of #{TYPES.keys.join(', ')}", caller
       end
@@ -135,7 +135,7 @@ module Finance
     #   Rate.to_effective(0.05, 4) #=> DecNum('0.05095')
     # @api public
     def Rate.to_effective(rate, periods)
-      rate, periods = rate.to_d, periods.to_d
+      rate, periods = Flt::DecNum.new(rate.to_d), Flt::DecNum.new(periods.to_d)
 
       if periods.infinite?
         rate.exp - 1
@@ -153,7 +153,7 @@ module Finance
     # @see http://www.miniwebtool.com/nominal-interest-rate-calculator/
     # @api public
     def Rate.to_nominal(rate, periods)
-      rate, periods = rate.to_d, periods.to_d
+      rate, periods = Flt::DecNum.new(rate.to_d), Flt::DecNum.new(periods.to_d)
 
       if periods.infinite?
         (rate + 1).log


### PR DESCRIPTION
I've dug into #9 a bit and it seems that the problem is that when you're in the Rails environment, Numeric.to_d that is overridden in the finance gem doesn't behave the same way.

In Rails console:

``` ruby
ruby-1.9.3-p194 :001 > 1.2.class
 => Float 
ruby-1.9.3-p194 :002 > 1.2.to_d.class
 => BigDecimal 
```

In irb:

``` ruby
ruby-1.9.3-p194 :001 > require 'finance'
 => true 
ruby-1.9.3-p194 :002 > 1.2.class
 => Float 
ruby-1.9.3-p194 :003 > 1.2.to_d.class
 => Flt::DecNum 
```

I've tried even adding the Numeric.to_d in a Rails initializer, but that didn't work. I created [this commit](https://github.com/thadd/finance/commit/9b85aea321355ae8c30593840db0e2a5987b6a5c) that takes a brute force approach and explicitly initializes all of the places where Flt::DecNum is expected rather than relying on to_d. This has (so far) fixed the issue for me.
