### PR TITLE
Remove the rake dependency from gemspec

### DIFF
--- a/finance.gemspec
+++ b/finance.gemspec
@@ -1,5 +1,4 @@
 require 'rubygems'
-require 'rake'
 
 SPEC = Gem::Specification.new do |s|
   s.name = "finance"
@@ -16,8 +15,7 @@ SPEC = Gem::Specification.new do |s|
   s.add_dependency 'flt', '>=1.3.0'
   s.add_development_dependency 'minitest', '>= 4.7.5'
   s.add_development_dependency 'activesupport', '>= 4.0.0'
-  s.files = FileList['README.md', 'COPYING', 'COPYING.LESSER', 'HISTORY', 'lib/**/*.rb', 'test/**/*.rb'].to_a
-
+  s.files = ['README.md', 'COPYING', 'COPYING.LESSER', 'HISTORY', Dir.glob('lib/**/*.rb'), Dir.glob('test/**/*.rb')].flatten
   s.has_rdoc = true
   s.extra_rdoc_files = ['README.md', 'COPYING', 'COPYING.LESSER', 'HISTORY']
 end


### PR DESCRIPTION
This was causing issues when upgrading to ruby 2.3. It would fail to require rake when initially doing a bundle install.
