### PR TITLE
Fixed bug where Numeric.amortize wouldn't work without first calling …

### DIFF
--- a/lib/finance.rb
+++ b/lib/finance.rb
@@ -9,7 +9,7 @@ require 'finance/cashflows'
 #  * *principal* represents the outstanding balance of a loan or annuity.
 #  * *rate* represents the interest rate _per period_.
 module Finance
-  autoload :Amortization, 'finance/amortization'
-  autoload :Rate,         'finance/rates'
-  autoload :Transaction,  'finance/transaction'
+  require 'finance/amortization'
+  require 'finance/rates'
+  require 'finance/transaction'
 end


### PR DESCRIPTION
…Amortization.new

## Before change, when calling amortize method on number, without first instanciating an Amortization, the numeric monkey patch isn't loaded

[1] pry(main)> require 'finance'
=> true
[2] pry(main)> include Finance
=> Object
[3] pry(main)> rate = Rate.new(0.3875,:apr,:duration => 360)
=> Rate.new(0.387500, :apr)
[4] pry(main)> 270000.amortize(rate)
NoMethodError: undefined method `amortize' for 270000:Fixnum
from (pry):4:in `__pry__'

## instanciating Amortization, now the patch is loaded.
[5] pry(main)> Amortization.new(100000,rate)
=> Amortization.new(100000)

## now it works
[6] pry(main)> 270000.amortize(rate)
=> Amortization.new(270000)
[7] pry(main)>
[7] pry(main)>

## After change, changed autoload to require, now it's always loaded.

[1] pry(main)> require 'finance'
=> true
[2] pry(main)> include Finance
=> Object
[3] pry(main)> rate = Rate.new(0.3875,:apr,:duration => 360)
=> Rate.new(0.387500, :apr)
[4] pry(main)> 270000.amortize(rate)
=> Amortization.new(270000)