### PR TITLE
Suppress `warning: BigDecimal.new is deprecated`

### DIFF
--- a/lib/finance/cashflows.rb
+++ b/lib/finance/cashflows.rb
@@ -22,7 +22,7 @@ module Finance
 
       values.each do |key, value|
         define_method key do
-          BigDecimal.new value
+          BigDecimal(value)
         end
       end
 
@@ -33,7 +33,7 @@ module Finance
 
       def values(x)
         value = @transactions.send(@function, Flt::DecNum.new(x[0].to_s))
-        [ BigDecimal.new(value.to_s) ]
+        [ BigDecimal(value.to_s) ]
       end
     end
 

--- a/lib/finance/decimal.rb
+++ b/lib/finance/decimal.rb
@@ -7,7 +7,7 @@ DecNum.context.define_conversion_from(BigDecimal) do |x, context|
 end
 
 DecNum.context.define_conversion_to(BigDecimal) do |x|
-  BigDecimal.new(x.to_s)
+  BigDecimal(x.to_s)
 end
 
 class Numeric


### PR DESCRIPTION
See similar change in Rails for Ruby 2.5 
https://github.com/rails/rails/commit/e4a6a23aa77185127ce9609777820fab14a689bb